### PR TITLE
fix conflict with Tabview YouTube Totara

### DIFF
--- a/frontend/chrome_extension/content_script/chat_window_toggler.ts
+++ b/frontend/chrome_extension/content_script/chat_window_toggler.ts
@@ -31,14 +31,18 @@ export class YouTubeChatWindowToggler implements ChatWindowToggler {
 
   private show(): void {
     this.containers.forEach((container) => {
-      container.style.display = "block";
+      if (container.style.display === "none") {
+        container.style.display = "";
+      }
     });
     this.window.dispatchEvent(new Event("resize"));
   }
 
   private hide(): void {
     this.containers.forEach((container) => {
-      container.style.display = "none";
+      if (container.style.display !== "none") {
+        container.style.display = "none";
+      }
     });
     this.window.dispatchEvent(new Event("resize"));
   }


### PR DESCRIPTION
@teststaybaka 

Danmage assigns the "display: block" to `chat-container` in YouTube. This conflicts with [Tabview YouTube Totara](https://greasyfork.org/scripts/501249-tabview-youtube-totara)'s `display:flex` disign.

Please consider this PR to fix the issue.


See discussion in https://greasyfork.org/scripts/501249-tabview-youtube-totara/discussions/316919

(You might also consider the similar fix in other elements)

----

Danmage 在 YouTube 中将 `chat-container` 设置为 `display: block`，这与 [Tabview YouTube Totara](https://greasyfork.org/scripts/501249-tabview-youtube-totara) 的 `display: flex` 设计发生了冲突。

请考虑合并此 PR 以修复该问题。

相关讨论见：
https://greasyfork.org/scripts/501249-tabview-youtube-totara/discussions/316919

(对其他元素你也可考虑类似修正）
